### PR TITLE
Encrypt with salt

### DIFF
--- a/strategies/singleFIle.js
+++ b/strategies/singleFIle.js
@@ -15,7 +15,7 @@ function singleFileStrategy (input, output, cipher, command) {
     const fileName = path.basename(parsedInput);
     
     if (inputExists && outputExists && command === 'encrypt') {
-      let enc = tricrypt('aes256', cipher);
+      let enc = tricrypt('aes-256-cbc', cipher);
       enc.encryptFile(input, output, fileName);      
     } 
     else if (inputExists && outputExists && command === 'decrypt') {

--- a/strategies/singleFIle.js
+++ b/strategies/singleFIle.js
@@ -19,7 +19,7 @@ function singleFileStrategy (input, output, cipher, command) {
       enc.encryptFile(input, output, fileName);      
     } 
     else if (inputExists && outputExists && command === 'decrypt') {
-      let dec = tricrypt('aes256', cipher);
+      let dec = tricrypt('aes-256-cbc', cipher);
       dec.decryptFile(input, output, fileName);      
     } else {
       throw new Error('Input not found.');


### PR DESCRIPTION
# Encryption and decryption strategies using salt

> resolve #2 

### Changes:

- Moved encryption and decryption strategies from ```aes256``` to ```aes-256-cbc```;
- Added salt using an ```initialization vector (iv)``` and the ```createCipheriv``` and ```createDecipheriv``` method;
- Saving ```iv``` inside file using the ```===tricrypt===``` string as separator between the inicialization vector and the encrypted data.